### PR TITLE
load jdk-classes in Kotlin testkit

### DIFF
--- a/testkit/src/main/java/com/qualityminds/lazyval/testkit/internal/toolchain/kotlin/KotlinCompilerSetup.java
+++ b/testkit/src/main/java/com/qualityminds/lazyval/testkit/internal/toolchain/kotlin/KotlinCompilerSetup.java
@@ -24,8 +24,6 @@ public record KotlinCompilerSetup(Path projectDir, CompilationService service,
                                   JvmCompilationConfiguration compilationConfig, List<File> sources,
                                   List<File> compilerClasspath) {
 
-
-
     private List<File> findAllSourceFiles(File file) {
         if (file.isDirectory()) {
             var files = file.listFiles();
@@ -73,6 +71,8 @@ public record KotlinCompilerSetup(Path projectDir, CompilationService service,
                     "-d", projectDir.resolve("build/classes").toAbsolutePath().toString(),
                     // classpath
                     "-classpath", classpathString,
+                    // needed to resolve Java types like LocalDate
+                    "-jdk-home", System.getProperty("java.home"),
                     // std-lib and kotlin-reflect will be added to classpath manually
                     // because the kotlin compiler otherwise expects a kotlin-stdlib on the filesystem
                     "-no-stdlib", "-no-reflect"

--- a/testkit/src/main/java/com/qualityminds/lazyval/testkit/internal/toolchain/kotlin/ToolchainSetup.java
+++ b/testkit/src/main/java/com/qualityminds/lazyval/testkit/internal/toolchain/kotlin/ToolchainSetup.java
@@ -142,6 +142,7 @@ public class ToolchainSetup {
                     builder.setLanguageVersion(kotlinVersion.toString());
                     builder.setApiVersion(kotlinVersion.getMajor() + "." + kotlinVersion.getMinor());
                     builder.setModuleName("test");
+                    builder.setJdkHome(Path.of(System.getProperty("java.home")).toFile());
                     builder.setProjectBaseDir(projectDir.toFile());
                     builder.setOutputBaseDir(Files.createDirectories(projectDir.resolve("build")).toFile());
                     builder.setClassOutputDir(Files.createDirectories(projectDir.resolve("build/classes")).toFile());

--- a/testkit/src/main/java/com/qualityminds/lazyval/testkit/scenarios/Scenario.java
+++ b/testkit/src/main/java/com/qualityminds/lazyval/testkit/scenarios/Scenario.java
@@ -183,6 +183,27 @@ public sealed interface Scenario {
             return Scenario.Java.of("scenarios/java/SocialSecurityNumber.java");
         }
 
+        /**
+         * A record wrapping a non-primitive reference type (LocalDate).
+         * <pre>{@code
+         * import java.time.LocalDate;
+         * import com.qualityminds.lazyval.LazyValue;
+         *
+         * @LazyValue
+         * public record Birthday(LocalDate value) {
+         *     public Birthday {
+         *         if (value == null) {
+         *             throw new IllegalArgumentException("Birthday must not be null");
+         *         }
+         *     }
+         * }
+         * }</pre>
+         * @return new ScenarioFactory instance
+         */
+        public static ScenarioFactory<Java> birthday() {
+            return Scenario.Java.of("scenarios/java/Birthday.java");
+        }
+
 //        /**
 //         * Combines all sources into a single scenario.
 //         * @return new ScenarioFactory instance
@@ -318,11 +339,27 @@ public sealed interface Scenario {
         }
 
         /**
+         * A data class wrapping a non-primitive reference type (LocalDate).
+         * <pre>{@code
+         * @LazyValue
+         * data class Birthday(val date: LocalDate) {
+         *     init {
+         *         require(date != null) { "Birthday date cannot be null" }
+         *     }
+         * }
+         * }</pre>
+         * @return new ScenarioFactory instance
+         */
+        public static ScenarioFactory<Kotlin> birthday() {
+            return Scenario.Kotlin.of("scenarios/kotlin/Birthday.kt");
+        }
+
+        /**
          * All predefined sample scenarios, without any dependencies.
          * @return immutable list of all predefined scenarios
          */
         public static List<ScenarioFactory<Kotlin>> all() {
-            return List.of(isbn(), quantity(), nullableQuantity(), productId());
+            return List.of(isbn(), quantity(), nullableQuantity(), productId(), birthday());
         }
     }
 

--- a/testkit/src/main/resources/scenarios/java/Birthday.java
+++ b/testkit/src/main/resources/scenarios/java/Birthday.java
@@ -1,0 +1,16 @@
+package scenarios.java;
+
+import com.qualityminds.lazyval.LazyValue;
+import java.time.LocalDate;
+
+@LazyValue
+public record Birthday(LocalDate value) {
+    public Birthday {
+        if (value == null) {
+            throw new IllegalArgumentException("Birthday must not be null");
+        }
+        if(value.isAfter(LocalDate.now())){
+            throw new IllegalArgumentException("Birthday must not be in the future");
+        }
+    }
+}

--- a/testkit/src/main/resources/scenarios/kotlin/Birthday.kt
+++ b/testkit/src/main/resources/scenarios/kotlin/Birthday.kt
@@ -1,0 +1,12 @@
+package scenarios.kotlin
+
+import com.qualityminds.lazyval.LazyValue;
+import java.time.LocalDate;
+
+@LazyValue
+data class Birthday(val date: LocalDate){
+
+    init {
+        require(!date.isAfter(LocalDate.now())) { "Birthday date cannot be in the future" }
+    }
+}


### PR DESCRIPTION
fixes #70
KSP and Kotlin compiler do not automatically load JDK types. They need to be provided with the "jdk-home" parameter to do so.

Also adds a test-scenario that wraps a LocalDate